### PR TITLE
GCC 4.8 support

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
     __ _____ _____ _____
  __|  |   __|     |   | |  JSON for Modern C++
 |  |  |__   |  |  | | | |  version 2.0.0
@@ -4873,7 +4873,13 @@ class basic_json
             // insert to array and return iterator
             iterator result(this);
             assert(m_value.array != nullptr);
-            result.m_it.array_iterator = m_value.array->insert(pos.m_it.array_iterator, cnt, val);
+            #if defined(__GNUC__) && __GNUC__ <= 4 && __GNUC_MINOR__ <= 8
+                 auto insert_pos = std::distance(m_value.array->begin(), pos.m_it.array_iterator);
+                 m_value.array->insert(pos.m_it.array_iterator, cnt, val);
+                 result.m_it.array_iterator = m_value.array->begin() + insert_pos;
+            #else
+                result.m_it.array_iterator = m_value.array->insert(pos.m_it.array_iterator, cnt, val);
+            #endif
             return result;
         }
         else
@@ -4939,10 +4945,19 @@ class basic_json
         // insert to array and return iterator
         iterator result(this);
         assert(m_value.array != nullptr);
-        result.m_it.array_iterator = m_value.array->insert(
+        
+        #if defined(__GNUC__) && __GNUC__ <= 4 && __GNUC_MINOR__ <= 8
+            auto insert_pos = std::distance(m_value.array->begin(), pos.m_it.array_iterator);
+            m_value.array->insert(pos.m_it.array_iterator, 
+                                  first.m_it.array_iterator,
+                                  last.m_it.array_iterator);
+            result.m_it.array_iterator = m_value.array->begin() + insert_pos;
+        #else
+            result.m_it.array_iterator = m_value.array->insert(
                                          pos.m_it.array_iterator,
                                          first.m_it.array_iterator,
                                          last.m_it.array_iterator);
+        #endif
         return result;
     }
 
@@ -4987,7 +5002,13 @@ class basic_json
         // insert to array and return iterator
         iterator result(this);
         assert(m_value.array != nullptr);
-        result.m_it.array_iterator = m_value.array->insert(pos.m_it.array_iterator, ilist);
+        #if defined(__GNUC__) && __GNUC__ <= 4 && __GNUC_MINOR__ <= 8
+            auto insert_pos = std::distance(m_value.array->begin(), pos.m_it.array_iterator);
+            m_value.array->insert(pos.m_it.array_iterator, ilist);
+            result.m_it.array_iterator = m_value.array->begin() + insert_pos;
+        #else
+            result.m_it.array_iterator = m_value.array->insert(pos.m_it.array_iterator, ilist);
+        #endif
         return result;
     }
 

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -4873,7 +4873,13 @@ class basic_json
             // insert to array and return iterator
             iterator result(this);
             assert(m_value.array != nullptr);
-            result.m_it.array_iterator = m_value.array->insert(pos.m_it.array_iterator, cnt, val);
+            #if defined(__GNUC__) && __GNUC__ <= 4 && __GNUC_MINOR__ <= 8
+                 auto insert_pos = std::distance(m_value.array->begin(), pos.m_it.array_iterator);
+                 m_value.array->insert(pos.m_it.array_iterator, cnt, val);
+                 result.m_it.array_iterator = m_value.array->begin() + insert_pos;
+            #else
+                result.m_it.array_iterator = m_value.array->insert(pos.m_it.array_iterator, cnt, val);
+            #endif            
             return result;
         }
         else
@@ -4939,10 +4945,18 @@ class basic_json
         // insert to array and return iterator
         iterator result(this);
         assert(m_value.array != nullptr);
-        result.m_it.array_iterator = m_value.array->insert(
+        #if defined(__GNUC__) && __GNUC__ <= 4 && __GNUC_MINOR__ <= 8
+            auto insert_pos = std::distance(m_value.array->begin(), pos.m_it.array_iterator);
+            m_value.array->insert(pos.m_it.array_iterator, 
+                                  first.m_it.array_iterator,
+                                  last.m_it.array_iterator);
+            result.m_it.array_iterator = m_value.array->begin() + insert_pos;
+        #else
+            result.m_it.array_iterator = m_value.array->insert(
                                          pos.m_it.array_iterator,
                                          first.m_it.array_iterator,
                                          last.m_it.array_iterator);
+        #endif                                         
         return result;
     }
 
@@ -4987,7 +5001,13 @@ class basic_json
         // insert to array and return iterator
         iterator result(this);
         assert(m_value.array != nullptr);
-        result.m_it.array_iterator = m_value.array->insert(pos.m_it.array_iterator, ilist);
+        #if defined(__GNUC__) && __GNUC__ <= 4 && __GNUC_MINOR__ <= 8
+            auto insert_pos = std::distance(m_value.array->begin(), pos.m_it.array_iterator);
+            m_value.array->insert(pos.m_it.array_iterator, ilist);
+            result.m_it.array_iterator = m_value.array->begin() + insert_pos;
+        #else
+            result.m_it.array_iterator = m_value.array->insert(pos.m_it.array_iterator, ilist);
+        #endif
         return result;
     }
 

--- a/src/json.hpp.re2c
+++ b/src/json.hpp.re2c
@@ -4874,9 +4874,9 @@ class basic_json
             iterator result(this);
             assert(m_value.array != nullptr);
             #if defined(__GNUC__) && __GNUC__ <= 4 && __GNUC_MINOR__ <= 8
-                 auto insert_pos = std::distance(m_value.array->begin(), pos.m_it.array_iterator);
-                 m_value.array->insert(pos.m_it.array_iterator, cnt, val);
-                 result.m_it.array_iterator = m_value.array->begin() + insert_pos;
+                auto insert_pos = std::distance(m_value.array->begin(), pos.m_it.array_iterator);
+                m_value.array->insert(pos.m_it.array_iterator, cnt, val);
+                result.m_it.array_iterator = m_value.array->begin() + insert_pos;
             #else
                 result.m_it.array_iterator = m_value.array->insert(pos.m_it.array_iterator, cnt, val);
             #endif            


### PR DESCRIPTION
## Files to change

There are currently two files which need to be edited:

1. [`src/json.hpp`](https://github.com/nlohmann/json/blob/master/src/json.hpp)

2. [`test/src/unit.cpp`](https://github.com/nlohmann/json/blob/master/test/unit.cpp) - This contains the [Catch](https://github.com/philsquared/Catch) unit tests which currently cover [100 %](https://coveralls.io/github/nlohmann/json) of the library's code.

   If you add or change a feature, please also add a unit test to this file. The unit tests can be compiled and executed with

   ```sh
   make check
   ```

   The test cases are also executed with several different compilers on [Travis](https://travis-ci.org/nlohmann/json) once you open a pull request.


## Note

- If you open a pull request, the code will be automatically tested with [Valgrind](http://valgrind.org)'s Memcheck tool to detect memory leaks. Please be aware that the execution with Valgrind _may_ in rare cases yield different behavior than running the code directly. This can result in failing unit tests which run successfully without Valgrind.

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.8 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](http://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
